### PR TITLE
Setup self-hosted n8n agent with docker

### DIFF
--- a/agents/n8n-agent/Dockerfile
+++ b/agents/n8n-agent/Dockerfile
@@ -1,0 +1,34 @@
+# Minimal image for n8n task-runner launcher with Node runtime available
+FROM node:20-bookworm-slim
+
+ARG USER=appuser
+ARG UID=10001
+
+# Install runtime deps: ca-certificates, curl, bash, tini
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl bash tini \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user and directories
+RUN useradd -m -u ${UID} -s /usr/sbin/nologin ${USER}
+
+WORKDIR /app
+
+# Copy launcher binary and scripts/config
+COPY bin/task-runner-launcher /usr/local/bin/task-runner-launcher
+COPY scripts/entrypoint.sh /entrypoint.sh
+COPY config/n8n-task-runners.json /etc/n8n-task-runners.json
+
+# Ensure permissions
+RUN chmod +x /usr/local/bin/task-runner-launcher /entrypoint.sh \
+  && chown -R ${USER}:${USER} /app /etc/n8n-task-runners.json
+
+# Healthcheck for launcher
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -sf http://127.0.0.1:${N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT:-5680}/healthz || exit 1
+
+USER ${USER}
+
+EXPOSE 5680
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/entrypoint.sh"]

--- a/agents/n8n-agent/bin/LICENSE.md
+++ b/agents/n8n-agent/bin/LICENSE.md
@@ -1,0 +1,86 @@
+# License
+
+Portions of this software are licensed as follows:
+
+- Content of branches other than the main branch (i.e. "main") are not licensed.
+- Source code files that contain ".ee." in their filename are NOT licensed under the Sustainable Use License.
+  To use source code files that contain ".ee." in their filename you must hold a valid n8n Enterprise License
+  specifically allowing you access to such source code files and as defined in "LICENSE_EE.md".
+- All third party components incorporated into the n8n Software are licensed under the original license
+  provided by the owner of the applicable component.
+- Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
+  License" as defined below.
+
+## Sustainable Use License
+
+Version 1.0
+
+### Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+### Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license
+to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject
+to the limitations below.
+
+### Limitations
+
+You may use or modify the software only for your own internal business purposes or for non-commercial or
+personal use. You may distribute the software or provide it to others only if you do so free of charge for
+non-commercial purposes. You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
+
+### Patents
+
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to
+license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case
+subject to the limitations and conditions in this license. This license does not cover any patent claims that
+you cause to be infringed by modifications or additions to the software. If you or your company make any
+written claim that the software infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+### Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these
+terms. If you modify the software, you must include in any modified copies of the software a prominent notice
+stating that you have modified the software.
+
+### No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+### Termination
+
+If you use the software in violation of these terms, such use is not licensed, and your license will
+automatically terminate. If the licensor provides you with a notice of your violation, and you cease all
+violation of this license no later than 30 days after you receive that notice, your license will be reinstated
+retroactively. However, if you violate these terms after such reinstatement, any additional violation of these
+terms will cause your license to terminate automatically and permanently.
+
+### No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will
+not be liable to you for any damages arising out of these terms or the use or nature of the software, under
+any kind of legal claim.
+
+### Definitions
+
+The “licensor” is the entity offering these terms.
+
+The “software” is the software the licensor makes available under these terms, including any portion of it.
+
+“You” refers to the individual or entity agreeing to these terms.
+
+“Your company” is any legal entity, sole proprietorship, or other kind of organization that you work for, plus
+all organizations that have control over, are under the control of, or are under common control with that
+organization. Control means ownership of substantially all the assets of an entity, or the power to direct its
+management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+“Your license” is the license granted to you for the software under these terms.
+
+“Use” means anything you do with the software requiring your license.
+
+“Trademark” means trademarks, service marks, and similar rights.

--- a/agents/n8n-agent/bin/LICENSE_EE.md
+++ b/agents/n8n-agent/bin/LICENSE_EE.md
@@ -1,0 +1,27 @@
+# The n8n Enterprise License (the “Enterprise License”)
+
+Copyright (c) 2022-present n8n GmbH.
+
+With regard to the n8n Software:
+
+This software and associated documentation files (the "Software") may only be used in production, if
+you (and any entity that you represent) hold a valid n8n Enterprise license corresponding to your
+usage. Subject to the foregoing sentence, you are free to modify this Software and publish patches
+to the Software. You agree that n8n and/or its licensors (as applicable) retain all right, title and
+interest in and to all such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise exploited with a valid n8n
+Enterprise license for the corresponding usage. Notwithstanding the foregoing, you may copy and
+modify the Software for development and testing purposes, without requiring a subscription. You
+agree that n8n and/or its licensors (as applicable) retain all right, title and interest in and to
+all such modifications. You are not granted any other rights beyond what is expressly stated herein.
+Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense, and/or
+sell the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For all third party components incorporated into the n8n Software, those components are licensed
+under the original license provided by the owner of the applicable component.

--- a/agents/n8n-agent/bin/README.md
+++ b/agents/n8n-agent/bin/README.md
@@ -1,0 +1,29 @@
+# task-runner-launcher
+
+[![codecov](https://codecov.io/gh/n8n-io/task-runner-launcher/graph/badge.svg?token=NW1BW05Q5P)](https://codecov.io/gh/n8n-io/task-runner-launcher)
+
+CLI utility to launch an [n8n task runner](https://docs.n8n.io/hosting/configuration/task-runners/) in `external` mode. The launcher's purpose is to minimize resource use by launching a runner on demand, i.e. only when no runner is available and when a task is ready for pickup. It also makes sure the runner stays responsive and recovers from crashes.
+
+```
+./task-runner-launcher javascript
+2024/11/29 13:37:46 INFO  [launcher:js] Starting launcher goroutine...
+2024/11/29 13:37:46 DEBUG [launcher:js] Changed into working directory
+2024/11/29 13:37:46 DEBUG [launcher:js] Prepared env vars for runner
+2024/11/29 13:37:46 INFO  [launcher:js] Waiting for task broker to be ready...
+2024/11/29 13:37:46 DEBUG [launcher:js] Task broker is ready
+2024/11/29 13:37:46 DEBUG [launcher:js] Fetched grant token for launcher
+2024/11/29 13:37:46 DEBUG [launcher:js] Launcher ID: fc6c24b9f764ae55
+2024/11/29 13:37:46 DEBUG [launcher:js] Connected: ws://127.0.0.1:5679/runners/_ws?id=fc6c24b9f764ae55
+2024/11/29 13:37:46 DEBUG [launcher:js] <- Received message `broker:inforequest`
+2024/11/29 13:37:46 DEBUG [launcher:js] -> Sent message `runner:info`
+2024/11/29 13:37:46 DEBUG [launcher:js] <- Received message `broker:runnerregistered`
+2024/11/29 13:37:46 DEBUG [launcher:js] -> Sent message `runner:taskoffer` for offer ID `5990b980a04945bd`
+2024/11/29 13:37:46 INFO  [launcher:js] Waiting for launcher's task offer to be accepted...
+```
+
+## Sections
+
+- [Setup](docs/setup.md) - how to set up the launcher in a production environment
+- [Development](docs/development.md) - how to set up a development environment to work on the launcher
+- [Release](docs/release.md) - how to release a new version of the launcher
+- [Lifecycle](docs/lifecycle.md) - how the launcher works

--- a/agents/n8n-agent/config/n8n-task-runners.json
+++ b/agents/n8n-agent/config/n8n-task-runners.json
@@ -1,0 +1,24 @@
+{
+  "task-runners": [
+    {
+      "runner-type": "javascript",
+      "workdir": "/usr/local/bin",
+      "command": "/usr/local/bin/node",
+      "args": [
+        "--disallow-code-generation-from-strings",
+        "--disable-proto=delete",
+        "/usr/local/lib/node_modules/n8n/node_modules/@n8n/task-runner/dist/start.js"
+      ],
+      "health-check-server-port": "5681",
+      "allowed-env": ["PATH", "GENERIC_TIMEZONE"],
+      "env-overrides": {
+        "N8N_RUNNERS_TASK_TIMEOUT": "80",
+        "N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT": "120",
+        "N8N_RUNNERS_MAX_CONCURRENCY": "3",
+        "NODE_FUNCTION_ALLOW_BUILTIN": "crypto",
+        "NODE_FUNCTION_ALLOW_EXTERNAL": "moment",
+        "NODE_OPTIONS": "--max-old-space-size=4096"
+      }
+    }
+  ]
+}

--- a/agents/n8n-agent/scripts/entrypoint.sh
+++ b/agents/n8n-agent/scripts/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default values if not provided
+: "${N8N_MAIN_URL:=http://localhost:5678}"
+: "${N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT:=5680}"
+: "${N8N_RUNNERS_BROKER_PORT:=5679}"
+
+if [[ -z "${N8N_RUNNERS_AUTH_TOKEN:-}" ]]; then
+  echo "ERROR: N8N_RUNNERS_AUTH_TOKEN is required" >&2
+  exit 1
+fi
+
+# Show minimal startup info
+echo "Starting n8n task-runner launcher..."
+
+echo "Main URL: ${N8N_MAIN_URL}"
+echo "Launcher health: :${N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT}"
+
+echo "Using config at /etc/n8n-task-runners.json"
+
+# Start launcher with javascript runner. Python runner requires separate base and deps.
+exec /usr/local/bin/task-runner-launcher javascript


### PR DESCRIPTION
Add a self-hosted n8n agent setup including Dockerfile, entrypoint, config, and the `task-runner-launcher` binary to enable local or containerized execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-60037271-1218-4ef7-a5d0-2398f033a297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60037271-1218-4ef7-a5d0-2398f033a297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

