### PR TITLE
Verify n8n agent container access

### DIFF
--- a/agents/n8n-agent/Dockerfile
+++ b/agents/n8n-agent/Dockerfile
@@ -9,13 +9,23 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl bash tini \
   && rm -rf /var/lib/apt/lists/*
 
+# Install n8n globally so task-runner exists in container
+RUN npm install -g n8n@latest
+
 # Create non-root user and directories
 RUN useradd -m -u ${UID} -s /usr/sbin/nologin ${USER}
 
 WORKDIR /app
 
-# Copy launcher binary and scripts/config
-COPY bin/task-runner-launcher /usr/local/bin/task-runner-launcher
+# Fetch launcher binary and copy scripts/config
+# Use latest release for linux amd64
+RUN curl -fsSL -o /tmp/launcher.tar.gz \
+    https://github.com/n8n-io/task-runner-launcher/releases/download/1.3.1/task-runner-launcher-1.3.1-linux-amd64.tar.gz \
+  && tar -xzf /tmp/launcher.tar.gz -C /usr/local/bin \
+  && if [ -f /usr/local/bin/task-runner-launcher-1.3.1-linux-amd64 ]; then mv /usr/local/bin/task-runner-launcher-1.3.1-linux-amd64 /usr/local/bin/task-runner-launcher; fi \
+  && chmod +x /usr/local/bin/task-runner-launcher \
+  && rm -f /tmp/launcher.tar.gz
+
 COPY scripts/entrypoint.sh /entrypoint.sh
 COPY config/n8n-task-runners.json /etc/n8n-task-runners.json
 


### PR DESCRIPTION
Automate n8n agent container setup by installing n8n and fetching the launcher binary in the Dockerfile.

---
<a href="https://cursor.com/background-agent?bcId=bc-018c278e-3b73-4766-85e1-fdcb5c85d3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-018c278e-3b73-4766-85e1-fdcb5c85d3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

